### PR TITLE
[SC-24a] Oracle Data Validation — Freshness & Staleness

### DIFF
--- a/smartcontract/contracts/volatility_shield/src/lib.rs
+++ b/smartcontract/contracts/volatility_shield/src/lib.rs
@@ -33,6 +33,9 @@ pub enum DataKey {
     FeePercentage,
     Token,
     Balance(Address),
+    OracleLastUpdate,
+    MaxStaleness,
+    OracleAllocations,
 }
 
 // ─────────────────────────────────────────────
@@ -162,13 +165,50 @@ impl VolatilityShield {
         env.events().publish((symbol_short!("Withdraw"), from.clone()), shares);
     }
 
+    // ── Oracle Data ──────────────────────────────
+    pub fn set_max_staleness(env: Env, caller: Address, max_staleness: u64) {
+        caller.require_auth();
+        let admin = Self::get_admin(&env);
+        if caller != admin { panic!("Unauthorized"); }
+        env.storage().instance().set(&DataKey::MaxStaleness, &max_staleness);
+    }
+
+    pub fn set_oracle_data(env: Env, caller: Address, allocations: Map<Address, i128>, timestamp: u64) {
+        caller.require_auth();
+        let oracle = Self::get_oracle(&env);
+        if caller != oracle { panic!("Unauthorized"); }
+
+        let current_time = env.ledger().timestamp();
+        let max_staleness: u64 = env.storage().instance().get(&DataKey::MaxStaleness).unwrap_or(3600);
+
+        if current_time > timestamp && current_time - timestamp > max_staleness {
+            env.events().publish((symbol_short!("Oracle"), symbol_short!("Reject")), timestamp);
+            panic!("Stale oracle data");
+        }
+
+        env.storage().instance().set(&DataKey::OracleLastUpdate, &timestamp);
+        env.storage().instance().set(&DataKey::OracleAllocations, &allocations);
+    }
+
     // ── Rebalance ─────────────────────────────
-    /// Move funds between strategies according to `allocations`.
-    pub fn rebalance(env: Env, allocations: Map<Address, i128>) {
+    /// Move funds between strategies according to stored `allocations`.
+    pub fn rebalance(env: Env, caller: Address) {
+        caller.require_auth();
         let admin  = Self::get_admin(&env);
         let oracle = Self::get_oracle(&env);
 
-        Self::require_admin_or_oracle(&env, &admin, &oracle);
+        if caller != admin && caller != oracle { panic!("Unauthorized"); }
+
+        let current_time = env.ledger().timestamp();
+        let last_update: u64 = env.storage().instance().get(&DataKey::OracleLastUpdate).expect("No oracle data");
+        let max_staleness: u64 = env.storage().instance().get(&DataKey::MaxStaleness).unwrap_or(3600);
+        
+        if current_time > last_update && current_time - last_update > max_staleness {
+            env.events().publish((symbol_short!("Oracle"), symbol_short!("Reject")), last_update);
+            panic!("Stale oracle data");
+        }
+
+        let allocations: Map<Address, i128> = env.storage().instance().get(&DataKey::OracleAllocations).expect("No allocations");
 
         let asset_addr   = Self::get_asset(&env);
         let token_client = token::Client::new(&env, &asset_addr);
@@ -309,13 +349,6 @@ impl VolatilityShield {
         env.storage().instance().set(&DataKey::Token, &token);
     }
 
-    fn require_admin_or_oracle(env: &Env, admin: &Address, oracle: &Address) {
-        if env.storage().instance().has(&DataKey::Admin) {
-            admin.require_auth();
-        } else {
-            oracle.require_auth();
-        }
-    }
 }
 
 mod test;

--- a/smartcontract/contracts/volatility_shield/src/test.rs
+++ b/smartcontract/contracts/volatility_shield/src/test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, Env, Map};
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, Map};
 use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::token::StellarAssetClient;
 
@@ -204,5 +204,36 @@ fn test_rebalance_admin_auth_accepted() {
     client.init(&admin, &asset, &oracle, &treasury, &0u32);
 
     let allocations: Map<Address, i128> = Map::new(&env);
-    client.rebalance(&allocations);
+    client.set_oracle_data(&oracle, &allocations, &1000);
+    env.ledger().with_mut(|li| {
+        li.timestamp = 2000;
+    });
+    client.rebalance(&admin);
+}
+
+#[test]
+#[should_panic(expected = "Stale oracle data")]
+fn test_oracle_staleness_rejected() {
+    let env         = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client      = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin  = Address::generate(&env);
+    let asset  = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(&admin, &asset, &oracle, &treasury, &0u32);
+
+    let allocations: Map<Address, i128> = Map::new(&env);
+    
+    client.set_oracle_data(&oracle, &allocations, &1000);
+    
+    env.ledger().with_mut(|li| {
+        li.timestamp = 5000;
+    });
+
+    client.rebalance(&admin);
 }

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_oracle_staleness_rejected.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_oracle_staleness_rejected.1.json
@@ -1,43 +1,28 @@
 {
   "generators": {
-    "address": 7,
+    "address": 5,
     "nonce": 0
   },
   "auth": [
     [],
     [],
-    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "add_strategy",
+              "function_name": "set_oracle_data",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "add_strategy",
-              "args": [
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                  "map": []
+                },
+                {
+                  "u64": 1000
                 }
               ]
             }
@@ -51,7 +36,7 @@
   "ledger": {
     "protocol_version": 22,
     "sequence_number": 0,
-    "timestamp": 0,
+    "timestamp": 5000,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -133,19 +118,36 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "OracleAllocations"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": []
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "OracleLastUpdate"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Strategies"
                             }
                           ]
                         },
                         "val": {
-                          "vec": [
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                            }
-                          ]
+                          "vec": []
                         }
                       },
                       {
@@ -185,7 +187,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -200,43 +202,10 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",
@@ -271,5 +240,29 @@
       ]
     ]
   },
-  "events": []
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "Oracle"
+              },
+              {
+                "symbol": "Reject"
+              }
+            ],
+            "data": {
+              "u64": 1000
+            }
+          }
+        }
+      },
+      "failed_call": true
+    }
+  ]
 }

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_rebalance_admin_auth_accepted.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_rebalance_admin_auth_accepted.1.json
@@ -8,6 +8,31 @@
     [],
     [
       [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_oracle_data",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "map": []
+                },
+                {
+                  "u64": 1000
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
@@ -16,7 +41,7 @@
               "function_name": "rebalance",
               "args": [
                 {
-                  "map": []
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -29,7 +54,7 @@
   "ledger": {
     "protocol_version": 22,
     "sequence_number": 0,
-    "timestamp": 0,
+    "timestamp": 2000,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -111,6 +136,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "OracleAllocations"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": []
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "OracleLastUpdate"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "Strategies"
                             }
                           ]
@@ -159,7 +208,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 801925984706572462
+                "nonce": 5541220902715666415
               }
             },
             "durability": "temporary"
@@ -172,6 +221,39 @@
               "contract_data": {
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462


### PR DESCRIPTION
## Summary
- Implemented `set_oracle_data` to save allocations with a timestamp.
- Updated `rebalance` to pull allocations from storage and validate freshness against `MAX_STALENESS`.
- Added test coverage demonstrating rejection of stale data.

Closes #35