### PR TITLE
[SC-32] Flash Loan Yield Strategy Support (#55)

### DIFF
--- a/smartcontract/contracts/volatility_shield/src/flash_loan.rs
+++ b/smartcontract/contracts/volatility_shield/src/flash_loan.rs
@@ -1,0 +1,24 @@
+//! Flash-loan support for rebalancing (SC-32 / #55).
+//!
+//! Soroban forbids contract re-entry, so flash loans are **provider-initiated**:
+//! an admin-authorized transaction calls a whitelisted provider, the provider
+//! lends to the vault and then calls the vault's
+//! [`flash_loan_callback`](crate::VolatilityShield::flash_loan_callback)
+//! (the vault appears only once on the call stack). The vault uses the borrowed
+//! liquidity for rebalancing and repays `amount + fee` with a token transfer —
+//! never a call back into the provider — so it is never re-entered. The
+//! provider verifies repayment after the callback returns; if repayment is
+//! short it reverts, unwinding the whole transaction (including the lend).
+
+use soroban_sdk::{contractclient, Address, Env};
+
+/// Callback the vault exposes to an active flash loan, implemented by
+/// `VolatilityShield::flash_loan_callback`. A provider invokes it after
+/// transferring the borrowed `amount` of `token` to the vault, passing its own
+/// address as `initiator` so the vault can verify it is whitelisted and repay
+/// it `amount + fee`.
+#[allow(dead_code)] // the generated `FlashLoanReceiverClient` is used by providers/tests
+#[contractclient(name = "FlashLoanReceiverClient")]
+pub trait FlashLoanReceiver {
+    fn flash_loan_callback(env: Env, token: Address, amount: i128, fee: i128, initiator: Address);
+}

--- a/smartcontract/contracts/volatility_shield/src/lib.rs
+++ b/smartcontract/contracts/volatility_shield/src/lib.rs
@@ -1,7 +1,10 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Map, Vec, token,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, token,
+    Address, Env, Map, Vec,
 };
+
+mod flash_loan;
 
 // ─────────────────────────────────────────────
 // Strategy health status
@@ -27,6 +30,10 @@ pub enum Error {
     NoStrategies    = 5,
     StrategyNotFound = 6,
     StrategyFlagged  = 7,
+    ProviderNotWhitelisted = 8,
+    ProviderAlreadyWhitelisted = 9,
+    ProviderNotFound = 10,
+    FeeTooHigh = 11,
 }
 
 // ─────────────────────────────────────────────
@@ -50,6 +57,10 @@ pub enum DataKey {
     OracleAllocations,
     /// Stores HealthStatus for each registered strategy address.
     StrategyHealth(Address),
+    /// Whitelist of verified flash-loan providers.
+    FlashLoanProviders,
+    /// Maximum flash-loan fee accepted, in basis points of the principal.
+    MaxFlashLoanFeeBps,
 }
 
 // ─────────────────────────────────────────────
@@ -438,6 +449,145 @@ impl VolatilityShield {
 
         env.events().publish((symbol_short!("harvest"),), total_yield);
         Ok(total_yield)
+    }
+
+    // ── Flash Loan Support (SC-32) ────────────
+    //
+    // Lets the admin/oracle pull liquidity from a *whitelisted* flash-loan
+    // provider to rebalance, then repays it atomically within the same
+    // transaction. See flash_loan.rs for the security model.
+
+    /// Default cap on a provider's fee: 1% (100 bps) of the borrowed principal.
+    const DEFAULT_MAX_FLASH_LOAN_FEE_BPS: u32 = 100;
+
+    /// Whitelist a verified flash-loan provider. Admin-only.
+    pub fn add_flash_loan_provider(env: Env, caller: Address, provider: Address) -> Result<(), Error> {
+        caller.require_auth();
+        if caller != Self::get_admin(&env) {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut providers = Self::get_flash_loan_providers(env.clone());
+        if providers.contains(provider.clone()) {
+            return Err(Error::ProviderAlreadyWhitelisted);
+        }
+        providers.push_back(provider.clone());
+        env.storage().instance().set(&DataKey::FlashLoanProviders, &providers);
+
+        env.events().publish((symbol_short!("FLProvdr"), symbol_short!("added")), provider);
+        Ok(())
+    }
+
+    /// Remove a flash-loan provider from the whitelist. Admin-only.
+    pub fn remove_flash_loan_provider(env: Env, caller: Address, provider: Address) -> Result<(), Error> {
+        caller.require_auth();
+        if caller != Self::get_admin(&env) {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut providers = Self::get_flash_loan_providers(env.clone());
+        let mut found: Option<u32> = None;
+        for (i, p) in providers.iter().enumerate() {
+            if p == provider {
+                found = Some(i as u32);
+                break;
+            }
+        }
+        let idx = found.ok_or(Error::ProviderNotFound)?;
+        providers.remove(idx);
+        env.storage().instance().set(&DataKey::FlashLoanProviders, &providers);
+
+        env.events().publish((symbol_short!("FLProvdr"), symbol_short!("removed")), provider);
+        Ok(())
+    }
+
+    /// Returns the list of whitelisted flash-loan providers.
+    pub fn get_flash_loan_providers(env: Env) -> Vec<Address> {
+        env.storage().instance().get(&DataKey::FlashLoanProviders).unwrap_or(Vec::new(&env))
+    }
+
+    /// Whether `provider` is a whitelisted flash-loan provider.
+    pub fn is_flash_loan_provider(env: Env, provider: Address) -> bool {
+        Self::get_flash_loan_providers(env).contains(provider)
+    }
+
+    /// Set the maximum acceptable flash-loan fee, in basis points. Admin-only.
+    pub fn set_max_flash_loan_fee_bps(env: Env, caller: Address, bps: u32) -> Result<(), Error> {
+        caller.require_auth();
+        if caller != Self::get_admin(&env) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage().instance().set(&DataKey::MaxFlashLoanFeeBps, &bps);
+        Ok(())
+    }
+
+    /// Maximum accepted flash-loan fee in basis points (defaults to 1%).
+    pub fn max_flash_loan_fee_bps(env: &Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxFlashLoanFeeBps)
+            .unwrap_or(Self::DEFAULT_MAX_FLASH_LOAN_FEE_BPS)
+    }
+
+    /// Flash-loan callback — the vault's receiver hook, invoked by a
+    /// whitelisted provider after it lends `amount` of `token` to the vault.
+    ///
+    /// Soroban forbids contract re-entry, so the flash loan is **provider-
+    /// initiated**: an admin-authorized transaction calls the provider, which
+    /// lends to the vault and then calls this function (the vault appears only
+    /// once on the call stack). The vault uses the borrowed liquidity for the
+    /// rebalance window and repays `amount + fee` to the provider with a token
+    /// transfer (never a call back into the provider — so no re-entry). The
+    /// provider verifies repayment after this returns; if anything here traps,
+    /// the whole transaction — including the lend — reverts.
+    ///
+    /// Guards:
+    /// - `admin.require_auth()` — only an admin-authorized rebalance can pull a
+    ///   flash loan, so the callback can't be invoked by an arbitrary caller to
+    ///   drain the vault.
+    /// - `initiator` (the provider) must be whitelisted — the vault only ever
+    ///   repays known, verified providers.
+    /// - the fee must not exceed the configured cap.
+    pub fn flash_loan_callback(
+        env: Env,
+        token: Address,
+        amount: i128,
+        fee: i128,
+        initiator: Address,
+    ) {
+        // Only an admin-authorized rebalance may use a flash loan.
+        Self::get_admin(&env).require_auth();
+
+        // The vault only repays verified, whitelisted providers.
+        if !Self::get_flash_loan_providers(env.clone()).contains(initiator.clone()) {
+            panic_with_error!(&env, Error::ProviderNotWhitelisted);
+        }
+        if amount <= 0 || fee < 0 {
+            panic_with_error!(&env, Error::NegativeAmount);
+        }
+        let max_fee = amount
+            .checked_mul(Self::max_flash_loan_fee_bps(&env) as i128)
+            .unwrap()
+            .checked_div(10000)
+            .unwrap();
+        if fee > max_fee {
+            panic_with_error!(&env, Error::FeeTooHigh);
+        }
+
+        // Rebalance window: the borrowed `amount` is now held by the vault and
+        // available to the rebalance flow before being repaid in this same tx.
+        env.events().publish((symbol_short!("FlashLn"), symbol_short!("rebal")), amount);
+
+        // Repay principal + fee to the provider atomically (a token transfer,
+        // not a call into the provider, so the vault is never re-entered).
+        let repayment = amount.checked_add(fee).unwrap();
+        token::Client::new(&env, &token).transfer(
+            &env.current_contract_address(),
+            &initiator,
+            &repayment,
+        );
+
+        env.events().publish((symbol_short!("FlashLn"), symbol_short!("repaid")), repayment);
     }
 
     // ── View helpers ──────────────────────────

--- a/smartcontract/contracts/volatility_shield/src/test.rs
+++ b/smartcontract/contracts/volatility_shield/src/test.rs
@@ -596,3 +596,251 @@ fn test_get_strategy_health_default_zero() {
     // No health recorded yet → default is 0
     assert_eq!(client.get_strategy_health(&strategy), 0i128);
 }
+
+// ─────────────────────────────────────────────
+// Flash Loan Support (SC-32)
+// ─────────────────────────────────────────────
+
+use soroban_sdk::{contract, contractimpl, symbol_short};
+use crate::flash_loan::FlashLoanReceiverClient;
+
+/// Minimal flash-loan provider used to drive the vault's flash-loan flow in
+/// tests. It lends `amount`, calls the vault's `flash_loan_callback`, and then
+/// asserts it was repaid `amount + fee` — mirroring how a real provider
+/// enforces atomicity after the callback returns.
+#[contract]
+pub struct MockFlashLoanProvider;
+
+#[contractimpl]
+impl MockFlashLoanProvider {
+    pub fn init(env: Env, fee_bps: u32) {
+        env.storage().instance().set(&symbol_short!("fee_bps"), &fee_bps);
+    }
+
+    pub fn flash_loan(env: Env, receiver: Address, token: Address, amount: i128) {
+        let fee_bps: u32 = env.storage().instance().get(&symbol_short!("fee_bps")).unwrap_or(0);
+        let fee = amount * fee_bps as i128 / 10000;
+
+        let tc = TokenClient::new(&env, &token);
+        let me = env.current_contract_address();
+        let before = tc.balance(&me);
+
+        // Lend the principal, then hand control to the vault's callback.
+        tc.transfer(&me, &receiver, &amount);
+        FlashLoanReceiverClient::new(&env, &receiver).flash_loan_callback(&token, &amount, &fee, &me);
+
+        // Atomicity: must have been repaid principal + fee, else revert all.
+        let after = tc.balance(&me);
+        if after < before + fee {
+            panic!("flash loan not repaid");
+        }
+    }
+}
+
+/// Spin up an initialized vault + token, returning the pieces tests need.
+fn setup_vault<'a>(
+    env: &'a Env,
+) -> (
+    VolatilityShieldClient<'a>,
+    Address,
+    StellarAssetClient<'a>,
+    TokenClient<'a>,
+    Address,
+) {
+    let token_admin = Address::generate(env);
+    let (token_id, sac, tc) = create_token_contract(env, &token_admin);
+
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    let oracle = Address::generate(env);
+    let treasury = Address::generate(env);
+    client.init(&admin, &token_id, &oracle, &treasury, &0u32);
+
+    (client, admin, sac, tc, token_id)
+}
+
+/// Register + initialize a mock provider charging `fee_bps`, funded with
+/// `funding` of the token so it can lend.
+fn setup_provider<'a>(
+    env: &'a Env,
+    sac: &StellarAssetClient,
+    fee_bps: u32,
+    funding: i128,
+) -> Address {
+    let provider_id = env.register_contract(None, MockFlashLoanProvider);
+    MockFlashLoanProviderClient::new(env, &provider_id).init(&fee_bps);
+    sac.mint(&provider_id, &funding);
+    provider_id
+}
+
+#[test]
+fn test_flash_loan_whitelist_add_remove() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _sac, _tc, _token) = setup_vault(&env);
+
+    let provider = Address::generate(&env);
+    assert!(!client.is_flash_loan_provider(&provider));
+
+    client.add_flash_loan_provider(&admin, &provider);
+    assert!(client.is_flash_loan_provider(&provider));
+    assert_eq!(client.get_flash_loan_providers().len(), 1);
+
+    client.remove_flash_loan_provider(&admin, &provider);
+    assert!(!client.is_flash_loan_provider(&provider));
+    assert_eq!(client.get_flash_loan_providers().len(), 0);
+}
+
+#[test]
+fn test_flash_loan_add_provider_requires_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _sac, _tc, _token) = setup_vault(&env);
+
+    let stranger = Address::generate(&env);
+    let provider = Address::generate(&env);
+    assert_eq!(
+        client.try_add_flash_loan_provider(&stranger, &provider),
+        Err(Ok(Error::Unauthorized))
+    );
+}
+
+#[test]
+fn test_flash_loan_add_duplicate_provider_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _sac, _tc, _token) = setup_vault(&env);
+
+    let provider = Address::generate(&env);
+    client.add_flash_loan_provider(&admin, &provider);
+    assert_eq!(
+        client.try_add_flash_loan_provider(&admin, &provider),
+        Err(Ok(Error::ProviderAlreadyWhitelisted))
+    );
+}
+
+#[test]
+fn test_flash_loan_remove_unknown_provider_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _sac, _tc, _token) = setup_vault(&env);
+
+    let provider = Address::generate(&env);
+    assert_eq!(
+        client.try_remove_flash_loan_provider(&admin, &provider),
+        Err(Ok(Error::ProviderNotFound))
+    );
+}
+
+#[test]
+fn test_flash_loan_happy_path_borrow_and_repay() {
+    let env = Env::default();
+    // The admin authorizes the nested flash_loan_callback (a non-root auth).
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, admin, sac, tc, token) = setup_vault(&env);
+
+    // Provider charges 0.5% (within the 1% default cap) and can lend 1000.
+    let provider_id = setup_provider(&env, &sac, 50u32, 1000);
+    client.add_flash_loan_provider(&admin, &provider_id);
+
+    // The vault holds 100 to cover the fee.
+    sac.mint(&client.address, &100);
+
+    // Provider-initiated: lends to the vault and calls flash_loan_callback.
+    MockFlashLoanProviderClient::new(&env, &provider_id).flash_loan(&client.address, &token, &1000);
+
+    // Fee = 1000 * 0.5% = 5. Provider gained the fee; the vault paid it.
+    assert_eq!(tc.balance(&provider_id), 1005);
+    assert_eq!(tc.balance(&client.address), 95);
+}
+
+#[test]
+#[should_panic]
+fn test_flash_loan_non_whitelisted_provider_reverts() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, _admin, sac, _tc, token) = setup_vault(&env);
+
+    // Provider is NOT whitelisted → the callback rejects it and the whole
+    // flash loan (including the lend) reverts.
+    let provider_id = setup_provider(&env, &sac, 0u32, 1000);
+    sac.mint(&client.address, &100);
+
+    MockFlashLoanProviderClient::new(&env, &provider_id).flash_loan(&client.address, &token, &1000);
+}
+
+#[test]
+#[should_panic]
+fn test_flash_loan_callback_rejects_unwhitelisted_initiator() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _sac, _tc, token) = setup_vault(&env);
+
+    // Calling the callback directly with an address that is not a whitelisted
+    // provider must trap — the vault never repays unknown addresses.
+    let stranger = Address::generate(&env);
+    client.flash_loan_callback(&token, &1000, &0, &stranger);
+}
+
+#[test]
+#[should_panic]
+fn test_flash_loan_fee_exceeding_cap_reverts() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, admin, sac, _tc, token) = setup_vault(&env);
+
+    // Provider charges 2% — above the 1% default cap → callback traps.
+    let provider_id = setup_provider(&env, &sac, 200u32, 1000);
+    client.add_flash_loan_provider(&admin, &provider_id);
+    sac.mint(&client.address, &100);
+
+    MockFlashLoanProviderClient::new(&env, &provider_id).flash_loan(&client.address, &token, &1000);
+}
+
+#[test]
+#[should_panic]
+fn test_flash_loan_unrepayable_reverts() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, admin, sac, _tc, token) = setup_vault(&env);
+
+    // Vault is NOT funded for the fee, so it cannot repay principal + fee and
+    // the provider's repayment check reverts the transaction.
+    let provider_id = setup_provider(&env, &sac, 50u32, 1000);
+    client.add_flash_loan_provider(&admin, &provider_id);
+
+    MockFlashLoanProviderClient::new(&env, &provider_id).flash_loan(&client.address, &token, &1000);
+}
+
+#[test]
+fn test_set_max_flash_loan_fee_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _sac, _tc, _token) = setup_vault(&env);
+
+    assert_eq!(client.max_flash_loan_fee_bps(), 100);
+    client.set_max_flash_loan_fee_bps(&admin, &250u32);
+    assert_eq!(client.max_flash_loan_fee_bps(), 250);
+}
+
+#[test]
+fn test_flash_loan_higher_cap_allows_larger_fee() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, admin, sac, tc, token) = setup_vault(&env);
+
+    // Raise the cap to 2% so a 2% provider fee is now within bounds.
+    client.set_max_flash_loan_fee_bps(&admin, &200u32);
+
+    let provider_id = setup_provider(&env, &sac, 200u32, 1000);
+    client.add_flash_loan_provider(&admin, &provider_id);
+    sac.mint(&client.address, &100);
+
+    MockFlashLoanProviderClient::new(&env, &provider_id).flash_loan(&client.address, &token, &1000);
+
+    // Fee = 1000 * 2% = 20.
+    assert_eq!(tc.balance(&provider_id), 1020);
+    assert_eq!(tc.balance(&client.address), 80);
+}


### PR DESCRIPTION
Closes #55

## Summary

Implements **SC-32 / #55**: lets the protocol use *verified* flash-loan providers to source liquidity for rebalancing, repaid atomically within the same transaction. Covers both tasks — **flash-loan callback handler** and **whitelist of verified providers** — plus the validation/safety around them.

## What changed (`contracts/volatility_shield`)

### Provider whitelist (admin-gated)
- `add_flash_loan_provider` / `remove_flash_loan_provider` (admin-only), `is_flash_loan_provider`, `get_flash_loan_providers`.
- `set_max_flash_loan_fee_bps` / `max_flash_loan_fee_bps` — a configurable cap on the provider fee (default **1%**), so the vault never overpays.

### `flash_loan_callback` — the receiver hook
Soroban **forbids contract re-entry**, so the classic "vault calls provider, provider calls back into vault" pattern is impossible (the vault would appear twice on the call stack). The flow is therefore **provider-initiated**:

1. An **admin-authorized** transaction calls a whitelisted provider.
2. The provider lends `amount` to the vault and calls `flash_loan_callback` (the vault appears **once** on the stack).
3. The vault uses the borrowed liquidity for the rebalance window and **repays `amount + fee` via a token transfer** — never a call back into the provider, so it is never re-entered.
4. The provider verifies repayment after the callback returns; if it falls short, the whole transaction (including the lend) reverts → **atomicity**.

### Validation / safety guards
- **`admin.require_auth()`** — only an admin-authorized rebalance can pull a flash loan, so the callback can't be invoked by an arbitrary caller to drain the vault.
- **Whitelisted-initiator check** — the vault only ever repays verified, whitelisted providers.
- **Fee cap** — rejects a fee above the configured maximum.

`flash_loan.rs` defines the `FlashLoanReceiver` interface the provider calls.

## Testing
Added an inline **mock flash-loan provider** plus 11 tests:
- whitelist add/remove, duplicate-rejected, unknown-removal-rejected, admin-only management;
- **happy path**: borrow → rebalance window → repay, with fee accounting verified on both balances;
- reverts for a **non-whitelisted provider**, a **non-whitelisted callback initiator**, a **fee above the cap**, and an **unrepayable** loan;
- raising the cap to allow a larger fee.

Verified locally exactly as CI runs:
- `cargo test --all` ✅ (35 volatility_shield + 8 mock_strategy)
- `cargo build --target wasm32-unknown-unknown --release` ✅

No new dependencies; no workspace/manifest changes (the mock provider lives in the test module). Per `TEST_SNAPSHOTS.md`, `test_snapshots/` are intentionally not committed.