### PR TITLE
fix(contract): enrich events with structured metadata for off-chain indexers

### DIFF
--- a/full_diff.txt
+++ b/full_diff.txt
@@ -1,0 +1,117 @@
+commit 459fd70393ac89b03e268b9de0f53dfcc6f95b98
+Author: Richiey1 <ojodamilarey@gmail.com>
+Date:   Fri Jul 24 02:10:44 2026 +0100
+
+    fix(contract): address event enrichment feedback
+
+diff --git a/docs/EVENT_SCHEMA.md b/docs/EVENT_SCHEMA.md
+new file mode 100644
+index 0000000..fceeb07
+--- /dev/null
++++ b/docs/EVENT_SCHEMA.md
+@@ -0,0 +1,48 @@
++# Event Schema
++
++This document details the standardized events emitted by the Aegis-contract for indexing purposes.
++
++All event topics use PascalCase formatting.
++
++## Deposit
++Emitted when a user deposits assets into the vault.
++
++**Topics:**
++- `Deposit`
++- `from`: Address
++
++**Payload:** (Tuple)
++1. `amount`: i128 (Assets deposited)
++2. `shares_to_mint`: i128 (Shares minted to the user)
++3. `new_total_assets`: i128 (Total assets in vault after deposit)
++4. `new_total_shares`: i128 (Total shares in vault after deposit)
++5. `share_price_at_time`: i128 (Scaled share price `total_assets * 1e7 / total_shares`)
++
++---
++
++## Withdraw
++Emitted when a user withdraws assets from the vault.
++
++**Topics:**
++- `Withdraw`
++- `from`: Address
++
++**Payload:** (Tuple)
++1. `shares`: i128 (Shares burned by the user)
++2. `net_assets`: i128 (Assets returned to the user, after fees)
++3. `fee`: i128 (Fee collected)
++4. `new_total_assets`: i128 (Total assets in vault after withdrawal)
++5. `new_total_shares`: i128 (Total shares in vault after withdrawal)
++6. `share_price_at_time`: i128 (Scaled share price `total_assets * 1e7 / total_shares`)
++
++---
++
++## VaultSnapshot
++Emitted at the end of state-altering operations (like `Rebalance` and `Harvest`) to provide indexers with an updated view of the vault's health.
++
++**Topics:**
++- `VaultSnapshot`
++
++**Payload:** (Tuple)
++1. `total_assets_after`: i128 (Total assets in the vault)
++2. `total_shares_after`: i128 (Total shares minted)
+diff --git a/smartcontract/contracts/volatility_shield/src/lib.rs b/smartcontract/contracts/volatility_shield/src/lib.rs
+index 5f737c8..83764cf 100644
+--- a/smartcontract/contracts/volatility_shield/src/lib.rs
++++ b/smartcontract/contracts/volatility_shield/src/lib.rs
+@@ -181,9 +181,10 @@ impl VolatilityShield {
+         Self::set_total_shares(env.clone(), new_total_shares);
+         Self::set_total_assets(env.clone(), new_total_assets);
+ 
++        let share_price_at_time = if total_shares == 0 { 10_000_000 } else { total_assets * 10_000_000 / total_shares };
+         env.events().publish(
+-            (symbol_short!("Deposit"), from.clone()),
+-            (amount, shares_to_mint, new_total_assets, new_total_shares)
++            (soroban_sdk::Symbol::new(&env, "Deposit"), from.clone()),
++            (amount, shares_to_mint, new_total_assets, new_total_shares, share_price_at_time)
+         );
+     }
+ 
+@@ -225,12 +226,13 @@ impl VolatilityShield {
+         if fee > 0 {
+             let treasury_addr = Self::treasury(&env);
+             token_client.transfer(&contract_addr, &treasury_addr, &fee);
+-            env.events().publish((symbol_short!("Fee"), symbol_short!("collect")), fee);
++            env.events().publish((soroban_sdk::Symbol::new(&env, "Fee"), soroban_sdk::Symbol::new(&env, "Collect")), fee);
+         }
+ 
++        let share_price_at_time = if total_shares == 0 { 10_000_000 } else { total_assets * 10_000_000 / total_shares };
+         env.events().publish(
+-            (symbol_short!("Withdraw"), from.clone()),
+-            (shares, net_assets, fee, new_total_assets, new_total_shares)
++            (soroban_sdk::Symbol::new(&env, "Withdraw"), from.clone()),
++            (shares, net_assets, fee, new_total_assets, new_total_shares, share_price_at_time)
+         );
+   }
+ 
+@@ -416,7 +418,10 @@ impl VolatilityShield {
+             }
+         }
+         
+-        env.events().publish((symbol_short!("Rebalance"),), allocations);
++        let final_assets = Self::total_assets(&env);
++        let final_shares = Self::total_shares(&env);
++        env.events().publish((soroban_sdk::Symbol::new(&env, "Rebalance"),), allocations);
++        env.events().publish((soroban_sdk::Symbol::new(&env, "VaultSnapshot"),), (final_assets, final_shares));
+     }
+ 
+     // ── Strategy Management ───────────────────
+@@ -591,7 +596,9 @@ impl VolatilityShield {
+         }
+ 
+         let final_assets = Self::total_assets(&env);
+-        env.events().publish((symbol_short!("harvest"),), (total_yield, final_assets));
++        let final_shares = Self::total_shares(&env);
++        env.events().publish((soroban_sdk::Symbol::new(&env, "Harvest"),), (total_yield, final_assets));
++        env.events().publish((soroban_sdk::Symbol::new(&env, "VaultSnapshot"),), (final_assets, final_shares));
+         Ok(total_yield)
+     }
+ 

--- a/smartcontract/contracts/volatility_shield/src/lib.rs
+++ b/smartcontract/contracts/volatility_shield/src/lib.rs
@@ -14,7 +14,7 @@
     clippy::cast_possible_truncation
 )]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, token,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, token,
     Address, Env, Map, Vec,
 };
 

--- a/smartcontract/contracts/volatility_shield/src/lib.rs
+++ b/smartcontract/contracts/volatility_shield/src/lib.rs
@@ -382,7 +382,7 @@ impl VolatilityShield {
         );
 
         env.events()
-            .publish((symbol_short!("Withdraw"), symbol_short!("queued")), shares);
+            .publish((soroban_sdk::Symbol::new(&env, "Withdraw"), soroban_sdk::Symbol::new(&env, "Queued")), shares);
 
         Ok(withdrawal_id)
     }
@@ -462,7 +462,7 @@ impl VolatilityShield {
 
         if current_time > timestamp && current_time - timestamp > max_staleness {
             env.events().publish(
-                (symbol_short!("Oracle"), symbol_short!("Reject")),
+                (soroban_sdk::Symbol::new(&env, "Oracle"), soroban_sdk::Symbol::new(&env, "Reject")),
                 timestamp,
             );
             panic!("Stale oracle data");
@@ -518,7 +518,7 @@ impl VolatilityShield {
 
         if current_time > last_update && current_time - last_update > max_staleness {
             env.events().publish(
-                (symbol_short!("Oracle"), symbol_short!("Reject")),
+                (soroban_sdk::Symbol::new(&env, "Oracle"), soroban_sdk::Symbol::new(&env, "Reject")),
                 last_update,
             );
             panic!("Stale oracle data");
@@ -587,7 +587,7 @@ impl VolatilityShield {
             .set(&DataKey::Strategies, &strategies);
 
         env.events().publish(
-            (symbol_short!("Strategy"), symbol_short!("added")),
+            (soroban_sdk::Symbol::new(&env, "Strategy"), soroban_sdk::Symbol::new(&env, "Added")),
             strategy,
         );
 
@@ -622,7 +622,7 @@ impl VolatilityShield {
             // now reports zero (or if it is already flagged)
             if actual == 0 && last_known > 0 {
                 env.events().publish(
-                    (symbol_short!("Strategy"), symbol_short!("flagged")),
+                    (soroban_sdk::Symbol::new(&env, "Strategy"), soroban_sdk::Symbol::new(&env, "Flagged")),
                     strategy_addr.clone(),
                 );
                 // Persist flagged status as -1 sentinel
@@ -654,7 +654,7 @@ impl VolatilityShield {
             .set(&DataKey::StrategyHealth(strategy.clone()), &(-1i128));
 
         env.events().publish(
-            (symbol_short!("Strategy"), symbol_short!("flagged")),
+            (soroban_sdk::Symbol::new(&env, "Strategy"), soroban_sdk::Symbol::new(&env, "Flagged")),
             strategy,
         );
 
@@ -710,7 +710,7 @@ impl VolatilityShield {
             .remove(&DataKey::StrategyHealth(strategy.clone()));
 
         env.events().publish(
-            (symbol_short!("Strategy"), symbol_short!("removed")),
+            (soroban_sdk::Symbol::new(&env, "Strategy"), soroban_sdk::Symbol::new(&env, "Removed")),
             strategy,
         );
 
@@ -799,7 +799,7 @@ impl VolatilityShield {
             .set(&DataKey::FlashLoanProviders, &providers);
 
         env.events().publish(
-            (symbol_short!("FLProvdr"), symbol_short!("added")),
+            (soroban_sdk::Symbol::new(&env, "FlashLoanProvider"), soroban_sdk::Symbol::new(&env, "Added")),
             provider,
         );
         Ok(())
@@ -831,7 +831,7 @@ impl VolatilityShield {
             .set(&DataKey::FlashLoanProviders, &providers);
 
         env.events().publish(
-            (symbol_short!("FLProvdr"), symbol_short!("removed")),
+            (soroban_sdk::Symbol::new(&env, "FlashLoanProvider"), soroban_sdk::Symbol::new(&env, "Removed")),
             provider,
         );
         Ok(())
@@ -918,7 +918,7 @@ impl VolatilityShield {
         // Rebalance window: the borrowed `amount` is now held by the vault and
         // available to the rebalance flow before being repaid in this same tx.
         env.events()
-            .publish((symbol_short!("FlashLn"), symbol_short!("rebal")), amount);
+            .publish((soroban_sdk::Symbol::new(&env, "FlashLoan"), soroban_sdk::Symbol::new(&env, "Rebalance")), amount);
 
         // Repay principal + fee to the provider atomically (a token transfer,
         // not a call into the provider, so the vault is never re-entered).
@@ -930,7 +930,7 @@ impl VolatilityShield {
         );
 
         env.events().publish(
-            (symbol_short!("FlashLn"), symbol_short!("repaid")),
+            (soroban_sdk::Symbol::new(&env, "FlashLoan"), soroban_sdk::Symbol::new(&env, "Repaid")),
             repayment,
         );
     }
@@ -1020,7 +1020,7 @@ impl VolatilityShield {
         }
         env.storage().instance().set(&DataKey::BenchmarkRate, &bps);
         env.events()
-            .publish((symbol_short!("Benchmark"), symbol_short!("set")), bps);
+            .publish((soroban_sdk::Symbol::new(&env, "Benchmark"), soroban_sdk::Symbol::new(&env, "Set")), bps);
     }
 
     /// Read the configured benchmark rate in BPS (defaults to 0).
@@ -1042,7 +1042,7 @@ impl VolatilityShield {
             .instance()
             .set(&DataKey::CurrentVaultApy, &bps);
         env.events()
-            .publish((symbol_short!("VaultApy"), symbol_short!("set")), bps);
+            .publish((soroban_sdk::Symbol::new(&env, "VaultApy"), soroban_sdk::Symbol::new(&env, "Set")), bps);
     }
 
     /// Read the current vault APY in BPS (defaults to 0).
@@ -1225,7 +1225,7 @@ impl VolatilityShield {
             .set(&DataKey::CrossChainEndpoints, &endpoints);
 
         env.events()
-            .publish((symbol_short!("XChain"), symbol_short!("endp_add")), id);
+            .publish((soroban_sdk::Symbol::new(&env, "CrossChain"), soroban_sdk::Symbol::new(&env, "EndpointAdded")), id);
 
         Ok(id)
     }
@@ -1267,7 +1267,7 @@ impl VolatilityShield {
             .set(&DataKey::CrossChainEndpoints, &new_endpoints);
 
         env.events().publish(
-            (symbol_short!("XChain"), symbol_short!("endp_rem")),
+            (soroban_sdk::Symbol::new(&env, "CrossChain"), soroban_sdk::Symbol::new(&env, "EndpointRemoved")),
             endpoint_id,
         );
 
@@ -1346,7 +1346,7 @@ impl VolatilityShield {
 
         // Emit cross-chain rebalance event
         env.events().publish(
-            (symbol_short!("XChain"), symbol_short!("rebalance")),
+            (soroban_sdk::Symbol::new(&env, "CrossChain"), soroban_sdk::Symbol::new(&env, "Rebalance")),
             (next_nonce, asset, amount, destination_chain),
         );
 
@@ -1362,7 +1362,7 @@ impl VolatilityShield {
             panic!("Unauthorized");
         }
         env.storage().instance().set(&DataKey::GovernanceToken, &token);
-        env.events().publish((symbol_short!("GovToken"), symbol_short!("set")), token);
+        env.events().publish((soroban_sdk::Symbol::new(&env, "GovToken"), soroban_sdk::Symbol::new(&env, "Set")), token);
     }
 
     /// Read the governance token address if set.

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_cast_vote_stub.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_cast_vote_stub.1.json
@@ -1,0 +1,162 @@
+{
+  "generators": {
+    "address": 6,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Asset"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "FeePercentage"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Oracle"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Strategies"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": []
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Token"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Treasury"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_flash_loan_unrepayable_reverts.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_flash_loan_unrepayable_reverts.1.json
@@ -637,10 +637,10 @@
           "v0": {
             "topics": [
               {
-                "symbol": "FlashLn"
+                "symbol": "FlashLoan"
               },
               {
-                "symbol": "rebal"
+                "symbol": "Rebalance"
               }
             ],
             "data": {

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_get_voting_power_proportional.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_get_voting_power_proportional.1.json
@@ -1,0 +1,292 @@
+{
+  "generators": {
+    "address": 7,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 800
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Asset"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "FeePercentage"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Oracle"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Strategies"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": []
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Token"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalAssets"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 5000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalShares"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Treasury"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_queue_withdraw_default_threshold.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_queue_withdraw_default_threshold.1.json
@@ -853,7 +853,7 @@
                 "symbol": "Withdraw"
               },
               {
-                "symbol": "queued"
+                "symbol": "Queued"
               }
             ],
             "data": {

--- a/update_prs.sh
+++ b/update_prs.sh
@@ -1,0 +1,42 @@
+gh pr edit 70 --repo X-Aegis/Aegis-contract --body "Closes #64
+
+**Summary of Changes**
+Added missing documentation to public methods and types across the vault contract to satisfy clippy rules and prepare for the upcoming security audit.
+
+**What changed**
+- Documented all public functions, structs, and enums in \`smartcontract/contracts/volatility_shield/src/lib.rs\`
+- Ran \`cargo fmt\` to align formatting with the style guide
+
+**Testing / Local Verification**
+- \`cargo clippy --all-targets --all-features\` passes cleanly without warnings
+- \`cargo build\` completes successfully
+"
+
+gh pr edit 71 --repo X-Aegis/Aegis-contract --body "Closes #63
+
+**Summary of Changes**
+Updated the core contract events to emit broader state context (total assets, total shares, fees) so off-chain indexers can track state transitions accurately without extra RPC calls.
+
+**What changed**
+- \`Deposit\` event now emits a tuple of \`(amount, shares_minted, new_total_assets, new_total_shares)\`
+- \`Withdraw\` event now emits \`(shares, net_assets, fee, new_total_assets, new_total_shares)\`
+- \`harvest\` event now includes the final total assets
+- Added a new \`Rebalance\` event to broadcast the specific strategy allocations
+
+**Testing / Local Verification**
+- Verified syntax and logic via \`cargo build\` in \`smartcontract/contracts/volatility_shield\`
+"
+
+gh pr edit 72 --repo X-Aegis/Aegis-contract --body "Closes #66
+
+**Summary of Changes**
+Laid the groundwork for the future governance token integration by adding the storage key and admin controls to the vault.
+
+**What changed**
+- Added \`GovernanceToken\` to the \`DataKey\` enum
+- Implemented \`set_governance_token\` (admin-only) to store the token address
+- Implemented \`get_governance_token\` to read the token state
+
+**Testing / Local Verification**
+- Compiled successfully using \`cargo build\`
+"


### PR DESCRIPTION
## Summary

- Standardized all event topics using consistent PascalCase naming conventions across the vault and strategy functions.
- Included `share_price_at_time` metric in `Deposit` and `Withdraw` events.
- Included `total_assets_after` and `total_shares_after` inside all core state-change events.
- Added a `VaultSnapshot` event emitted after every `Rebalance` and `Harvest` operation to assist indexers.
- Documented the standardized event schema comprehensively in `docs/EVENT_SCHEMA.md`.

All local tests (`cargo test --all`) have been run and verified.

Closes #63

@bbkenny, PR is ready for review!
