### PR TITLE
[SC-25a] Withdrawal Queue — Core Queue Mechanism

### DIFF
--- a/smartcontract/contracts/volatility_shield/src/lib.rs
+++ b/smartcontract/contracts/volatility_shield/src/lib.rs
@@ -330,8 +330,9 @@ impl VolatilityShield {
     // ── Withdrawal Queue ───────────────────────
 
     /// Queue a withdrawal when `shares` exceeds the configured threshold.
-    /// The withdrawal is stored in the pending queue and must be processed
-    /// by the admin/oracle via `process_queued_withdrawal`.
+    /// The withdrawal is stored in the pending queue (keyed by its assigned
+    /// `withdrawal_id`) and must be processed by the admin via
+    /// `process_queued_withdrawal`.
     pub fn queue_withdraw(env: Env, from: Address, shares: i128) -> Result<u32, Error> {
         if shares <= 0 {
             panic!("shares to withdraw must be positive");
@@ -371,9 +372,18 @@ impl VolatilityShield {
             processed: false,
         };
 
+        // Store queued withdrawals in a map keyed by withdrawal_id so that
+        // multiple concurrent pending withdrawals coexist instead of
+        // clobbering one another under a single flat key.
+        let mut pending_withdrawals: Map<u32, PendingWithdrawal> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingWithdrawals)
+            .unwrap_or_else(|| Map::new(&env));
+        pending_withdrawals.set(withdrawal_id, pending.clone());
         env.storage()
             .persistent()
-            .set(&DataKey::PendingWithdrawals, &pending);
+            .set(&DataKey::PendingWithdrawals, &pending_withdrawals);
 
         // Deduct shares immediately so they cannot be double-spent
         env.storage().persistent().set(
@@ -381,10 +391,103 @@ impl VolatilityShield {
             &(current_balance.checked_sub(shares).unwrap()),
         );
 
-        env.events()
-            .publish((soroban_sdk::Symbol::new(&env, "Withdraw"), soroban_sdk::Symbol::new(&env, "Queued")), shares);
+        env.events().publish(
+            (soroban_sdk::Symbol::new(&env, "Withdraw"), soroban_sdk::Symbol::new(&env, "Queued")),
+            (withdrawal_id, from.clone(), shares, pending.created_at),
+        );
 
         Ok(withdrawal_id)
+    }
+
+    /// Process a previously queued withdrawal. Admin-only.
+    ///
+    /// Converts the queued `shares` to assets at the *current* share price,
+    /// applies the standard withdrawal fee, transfers the net assets to the
+    /// original requester, and marks the entry as processed so it cannot be
+    /// settled twice.
+    ///
+    /// # Errors
+    /// * `Error::Unauthorized` if `caller` is not the admin.
+    /// * `Error::WithdrawalNotFound` if `withdrawal_id` has no queued entry.
+    /// * `Error::WithdrawalAlreadyProcessed` if the entry was already settled.
+    pub fn process_queued_withdrawal(
+        env: Env,
+        caller: Address,
+        withdrawal_id: u32,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+        let admin = Self::get_admin(&env);
+        if caller != admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut pending_withdrawals: Map<u32, PendingWithdrawal> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingWithdrawals)
+            .unwrap_or_else(|| Map::new(&env));
+
+        let mut pending = pending_withdrawals
+            .get(withdrawal_id)
+            .ok_or(Error::WithdrawalNotFound)?;
+
+        if pending.processed {
+            return Err(Error::WithdrawalAlreadyProcessed);
+        }
+
+        let assets_to_withdraw = Self::convert_to_assets(env.clone(), pending.shares);
+        let (net_assets, fee) = Self::take_fees(&env, assets_to_withdraw);
+
+        let total_shares = Self::total_shares(&env);
+        let total_assets = Self::total_assets(&env);
+        let new_total_shares = total_shares.checked_sub(pending.shares).unwrap();
+        let new_total_assets = total_assets.checked_sub(assets_to_withdraw).unwrap();
+        Self::set_total_shares(env.clone(), new_total_shares);
+        Self::set_total_assets(env.clone(), new_total_assets);
+
+        let token_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .expect("Token not initialized");
+        let token_client = token::Client::new(&env, &token_addr);
+        let contract_addr = env.current_contract_address();
+
+        // 1. Transfer net assets to the original requester
+        token_client.transfer(&contract_addr, &pending.from, &net_assets);
+
+        // 2. Transfer fee to treasury if any
+        if fee > 0 {
+            let treasury_addr = Self::treasury(&env);
+            token_client.transfer(&contract_addr, &treasury_addr, &fee);
+            env.events().publish(
+                (soroban_sdk::Symbol::new(&env, "Fee"), soroban_sdk::Symbol::new(&env, "Collect")),
+                fee,
+            );
+        }
+
+        pending.processed = true;
+        pending_withdrawals.set(withdrawal_id, pending.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingWithdrawals, &pending_withdrawals);
+
+        env.events().publish(
+            (soroban_sdk::Symbol::new(&env, "Withdraw"), soroban_sdk::Symbol::new(&env, "Processed")),
+            (withdrawal_id, pending.from.clone(), pending.shares, net_assets, fee, new_total_assets, new_total_shares),
+        );
+
+        Ok(())
+    }
+
+    /// Returns a queued withdrawal by its `withdrawal_id`, if one exists.
+    pub fn get_pending_withdrawal(env: Env, withdrawal_id: u32) -> Option<PendingWithdrawal> {
+        let pending_withdrawals: Map<u32, PendingWithdrawal> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingWithdrawals)
+            .unwrap_or_else(|| Map::new(&env));
+        pending_withdrawals.get(withdrawal_id)
     }
 
     /// Set the withdrawal queue threshold. Admin-only.

--- a/smartcontract/contracts/volatility_shield/src/test.rs
+++ b/smartcontract/contracts/volatility_shield/src/test.rs
@@ -1139,6 +1139,216 @@ fn test_queue_withdraw_insufficient_shares_rejected() {
 }
 
 #[test]
+fn test_queue_withdraw_multiple_entries_do_not_overwrite() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (token, sac, tc) = create_token_contract(&env, &Address::generate(&env));
+    let admin = Address::generate(&env);
+    sac.mint(&admin, &100_000_000_000_000i128);
+
+    let contract_id = env.register(VolatilityShield, ());
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(&admin, &token, &oracle, &treasury, &0u32);
+
+    tc.transfer(&admin, &client.address, &100_000);
+    client.set_total_assets(&100_000);
+    client.set_total_shares(&2_000);
+    client.set_balance(&admin, &2_000);
+
+    client.set_withdraw_queue_threshold(&admin, &500);
+
+    // Queue two separate withdrawals from the same account.
+    let id1 = client.queue_withdraw(&admin, &600);
+    let id2 = client.queue_withdraw(&admin, &700);
+
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+    assert_ne!(id1, id2);
+
+    // Both must be independently retrievable — the second queue_withdraw
+    // call must not have clobbered the first (the regression this test
+    // guards against).
+    let pending1 = client.get_pending_withdrawal(&id1).unwrap();
+    let pending2 = client.get_pending_withdrawal(&id2).unwrap();
+
+    assert_eq!(pending1.from, admin);
+    assert_eq!(pending1.shares, 600);
+    assert!(!pending1.processed);
+
+    assert_eq!(pending2.from, admin);
+    assert_eq!(pending2.shares, 700);
+    assert!(!pending2.processed);
+
+    // Shares were deducted for both withdrawals.
+    assert_eq!(client.balance(&admin), 700);
+}
+
+#[test]
+fn test_queue_withdraw_multiple_accounts_independent() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (token, sac, tc) = create_token_contract(&env, &Address::generate(&env));
+    let admin = Address::generate(&env);
+    sac.mint(&admin, &100_000_000_000_000i128);
+
+    let contract_id = env.register(VolatilityShield, ());
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    client.init(&admin, &token, &oracle, &treasury, &0u32);
+
+    tc.transfer(&admin, &client.address, &100_000);
+    client.set_total_assets(&100_000);
+    client.set_total_shares(&2_000);
+    client.set_balance(&admin, &1_000);
+    client.set_balance(&user2, &1_000);
+
+    client.set_withdraw_queue_threshold(&admin, &500);
+
+    let id1 = client.queue_withdraw(&admin, &600);
+    let id2 = client.queue_withdraw(&user2, &900);
+
+    let pending1 = client.get_pending_withdrawal(&id1).unwrap();
+    let pending2 = client.get_pending_withdrawal(&id2).unwrap();
+
+    assert_eq!(pending1.from, admin);
+    assert_eq!(pending1.shares, 600);
+    assert_eq!(pending2.from, user2);
+    assert_eq!(pending2.shares, 900);
+}
+
+#[test]
+fn test_process_queued_withdrawal_transfers_assets() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (token, sac, tc) = create_token_contract(&env, &Address::generate(&env));
+    let admin = Address::generate(&env);
+    sac.mint(&admin, &100_000_000_000_000i128);
+
+    let contract_id = env.register(VolatilityShield, ());
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(&admin, &token, &oracle, &treasury, &0u32);
+
+    tc.transfer(&admin, &client.address, &100_000);
+    client.set_total_assets(&100_000);
+    client.set_total_shares(&1_000);
+    client.set_balance(&admin, &1_000);
+
+    client.set_withdraw_queue_threshold(&admin, &500);
+
+    let id = client.queue_withdraw(&admin, &600);
+
+    let balance_before = tc.balance(&admin);
+    client.process_queued_withdrawal(&admin, &id);
+    let balance_after = tc.balance(&admin);
+
+    // 600 shares out of 1000 total shares backed by 100_000 assets = 60_000 assets.
+    assert_eq!(balance_after - balance_before, 60_000);
+
+    let pending = client.get_pending_withdrawal(&id).unwrap();
+    assert!(pending.processed);
+
+    assert_eq!(client.total_shares(), 400);
+    assert_eq!(client.total_assets(), 40_000);
+}
+
+#[test]
+fn test_process_queued_withdrawal_not_found() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (token, _sac, _tc) = create_token_contract(&env, &Address::generate(&env));
+    let admin = Address::generate(&env);
+
+    let contract_id = env.register(VolatilityShield, ());
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(&admin, &token, &oracle, &treasury, &0u32);
+
+    let result = client.try_process_queued_withdrawal(&admin, &999);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_process_queued_withdrawal_already_processed_rejected() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (token, sac, tc) = create_token_contract(&env, &Address::generate(&env));
+    let admin = Address::generate(&env);
+    sac.mint(&admin, &100_000_000_000_000i128);
+
+    let contract_id = env.register(VolatilityShield, ());
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(&admin, &token, &oracle, &treasury, &0u32);
+
+    tc.transfer(&admin, &client.address, &100_000);
+    client.set_total_assets(&100_000);
+    client.set_total_shares(&1_000);
+    client.set_balance(&admin, &1_000);
+
+    client.set_withdraw_queue_threshold(&admin, &500);
+
+    let id = client.queue_withdraw(&admin, &600);
+    client.process_queued_withdrawal(&admin, &id);
+
+    let result = client.try_process_queued_withdrawal(&admin, &id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_process_queued_withdrawal_unauthorized_rejected() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (token, sac, tc) = create_token_contract(&env, &Address::generate(&env));
+    let admin = Address::generate(&env);
+    sac.mint(&admin, &100_000_000_000_000i128);
+
+    let contract_id = env.register(VolatilityShield, ());
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let not_admin = Address::generate(&env);
+
+    client.init(&admin, &token, &oracle, &treasury, &0u32);
+
+    tc.transfer(&admin, &client.address, &100_000);
+    client.set_total_assets(&100_000);
+    client.set_total_shares(&1_000);
+    client.set_balance(&admin, &1_000);
+
+    client.set_withdraw_queue_threshold(&admin, &500);
+
+    let id = client.queue_withdraw(&admin, &600);
+
+    let result = client.try_process_queued_withdrawal(&not_admin, &id);
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_set_and_get_queue_threshold() {
     let env = Env::default();
     env.mock_all_auths_allowing_non_root_auth();

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_process_queued_withdrawal_already_processed_rejected.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_process_queued_withdrawal_already_processed_rejected.1.json
@@ -131,6 +131,28 @@
         }
       ]
     ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "process_queued_withdrawal",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u32": 1
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     []
   ],
   "ledger": {
@@ -309,6 +331,39 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
                 "nonce": 4837995959683129791
               }
             },
@@ -442,7 +497,7 @@
                               "symbol": "processed"
                             },
                             "val": {
-                              "bool": false
+                              "bool": true
                             }
                           },
                           {
@@ -574,7 +629,7 @@
                         "val": {
                           "i128": {
                             "hi": 0,
-                            "lo": 100000
+                            "lo": 40000
                           }
                         }
                       },
@@ -589,7 +644,7 @@
                         "val": {
                           "i128": {
                             "hi": 0,
-                            "lo": 1000
+                            "lo": 400
                           }
                         }
                       },
@@ -686,7 +741,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 99999999900000
+                          "lo": 99999999960000
                         }
                       }
                     },
@@ -759,7 +814,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 100000
+                          "lo": 40000
                         }
                       }
                     },

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_process_queued_withdrawal_not_found.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_process_queued_withdrawal_not_found.1.json
@@ -1,0 +1,354 @@
+{
+  "generators": {
+    "address": 6,
+    "nonce": 0
+  },
+  "auth": [
+    [
+      [
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "account": {
+            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "account": {
+                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+                "balance": 0,
+                "seq_num": 0,
+                "num_sub_entries": 0,
+                "inflation_dest": null,
+                "flags": 0,
+                "home_domain": "",
+                "thresholds": "01010101",
+                "signers": [],
+                "ext": "v0"
+              }
+            },
+            "ext": "v0"
+          },
+          null
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Asset"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "FeePercentage"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Oracle"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Strategies"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": []
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Token"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Treasury"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": "stellar_asset",
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "METADATA"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "decimal"
+                              },
+                              "val": {
+                                "u32": 7
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "aaa"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AssetInfo"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "AlphaNum4"
+                            },
+                            {
+                              "map": [
+                                {
+                                  "key": {
+                                    "symbol": "asset_code"
+                                  },
+                                  "val": {
+                                    "string": "aaa\\0"
+                                  }
+                                },
+                                {
+                                  "key": {
+                                    "symbol": "issuer"
+                                  },
+                                  "val": {
+                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000002"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          120960
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_process_queued_withdrawal_transfers_assets.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_process_queued_withdrawal_transfers_assets.1.json
@@ -131,6 +131,32 @@
         }
       ]
     ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "process_queued_withdrawal",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u32": 1
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [],
     []
   ],
   "ledger": {
@@ -309,6 +335,39 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
                 "nonce": 4837995959683129791
               }
             },
@@ -442,7 +501,7 @@
                               "symbol": "processed"
                             },
                             "val": {
-                              "bool": false
+                              "bool": true
                             }
                           },
                           {
@@ -574,7 +633,7 @@
                         "val": {
                           "i128": {
                             "hi": 0,
-                            "lo": 100000
+                            "lo": 40000
                           }
                         }
                       },
@@ -589,7 +648,7 @@
                         "val": {
                           "i128": {
                             "hi": 0,
-                            "lo": 1000
+                            "lo": 400
                           }
                         }
                       },
@@ -686,7 +745,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 99999999900000
+                          "lo": 99999999960000
                         }
                       }
                     },
@@ -759,7 +818,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 100000
+                          "lo": 40000
                         }
                       }
                     },

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_process_queued_withdrawal_unauthorized_rejected.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_process_queued_withdrawal_unauthorized_rejected.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 6,
+    "address": 7,
     "nonce": 0
   },
   "auth": [

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_queue_withdraw_default_threshold.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_queue_withdraw_default_threshold.1.json
@@ -358,37 +358,46 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "created_at"
+                        "u32": 1
                       },
                       "val": {
-                        "u64": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "from"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "processed"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "shares"
-                      },
-                      "val": {
-                        "i128": {
-                          "hi": 0,
-                          "lo": 100
-                        }
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "created_at"
+                            },
+                            "val": {
+                              "u64": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "from"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "processed"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "shares"
+                            },
+                            "val": {
+                              "i128": {
+                                "hi": 0,
+                                "lo": 100
+                              }
+                            }
+                          }
+                        ]
                       }
                     }
                   ]
@@ -857,10 +866,23 @@
               }
             ],
             "data": {
-              "i128": {
-                "hi": 0,
-                "lo": 100
-              }
+              "vec": [
+                {
+                  "u32": 1
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
+                },
+                {
+                  "u64": 0
+                }
+              ]
             }
           }
         }

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_queue_withdraw_multiple_accounts_independent.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_queue_withdraw_multiple_accounts_independent.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 6,
+    "address": 7,
     "nonce": 0
   },
   "auth": [
@@ -81,6 +81,7 @@
     [],
     [],
     [],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
@@ -131,6 +132,32 @@
         }
       ]
     ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "queue_withdraw",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 900
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
     []
   ],
   "ledger": {
@@ -391,6 +418,54 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "vec": [
+                {
                   "symbol": "PendingWithdrawals"
                 }
               ]
@@ -453,6 +528,50 @@
                               "i128": {
                                 "hi": 0,
                                 "lo": 600
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "u32": 2
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "created_at"
+                            },
+                            "val": {
+                              "u64": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "from"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "processed"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "shares"
+                            },
+                            "val": {
+                              "i128": {
+                                "hi": 0,
+                                "lo": 900
                               }
                             }
                           }
@@ -589,7 +708,7 @@
                         "val": {
                           "i128": {
                             "hi": 0,
-                            "lo": 1000
+                            "lo": 2000
                           }
                         }
                       },
@@ -614,7 +733,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 1
+                          "u32": 2
                         }
                       },
                       {
@@ -640,6 +759,39 @@
             "ext": "v0"
           },
           4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
         ]
       ],
       [

--- a/smartcontract/contracts/volatility_shield/test_snapshots/test/test_queue_withdraw_multiple_entries_do_not_overwrite.1.json
+++ b/smartcontract/contracts/volatility_shield/test_snapshots/test/test_queue_withdraw_multiple_entries_do_not_overwrite.1.json
@@ -131,6 +131,33 @@
         }
       ]
     ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "queue_withdraw",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 700
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
     []
   ],
   "ledger": {
@@ -309,6 +336,39 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
                 "nonce": 4837995959683129791
               }
             },
@@ -374,7 +434,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 400
+                    "lo": 700
                   }
                 }
               }
@@ -453,6 +513,50 @@
                               "i128": {
                                 "hi": 0,
                                 "lo": 600
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "u32": 2
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "created_at"
+                            },
+                            "val": {
+                              "u64": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "from"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "processed"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "shares"
+                            },
+                            "val": {
+                              "i128": {
+                                "hi": 0,
+                                "lo": 700
                               }
                             }
                           }
@@ -589,7 +693,7 @@
                         "val": {
                           "i128": {
                             "hi": 0,
-                            "lo": 1000
+                            "lo": 2000
                           }
                         }
                       },
@@ -614,7 +718,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 1
+                          "u32": 2
                         }
                       },
                       {


### PR DESCRIPTION
## Summary

Fixes issue #62 [SC-25a]: `DataKey::PendingWithdrawals` was documented as a "Map of queued withdrawal IDs to PendingWithdrawal data" but the code stored a single `PendingWithdrawal` struct under one flat key, so every new `queue_withdraw` call silently overwrote the previous pending entry.

- `queue_withdraw` now stores queued withdrawals in a real `Map<u32, PendingWithdrawal>` under `DataKey::PendingWithdrawals`, keyed by the withdrawal's assigned `withdrawal_id`, so multiple concurrent pending withdrawals coexist instead of clobbering one another.
- Added `process_queued_withdrawal(env, caller, withdrawal_id)`: admin-gated (`Error::Unauthorized` otherwise), looks up the entry (`Error::WithdrawalNotFound` if missing), rejects already-settled entries (`Error::WithdrawalAlreadyProcessed`), converts shares to assets at the current share price, applies the standard withdrawal fee via `take_fees`, transfers net assets to the original requester and the fee to treasury using `token::Client` (mirroring the existing `withdraw()` flow), updates `total_shares`/`total_assets`, marks the entry `processed = true`, and emits a `Withdraw`/`Processed` event.
- Added `get_pending_withdrawal(env, withdrawal_id)` view helper for inspecting queued entries.
- `WithdrawQueued` event now includes `(withdrawal_id, from, shares, created_at)` instead of just `shares`.

## Test plan

New tests added in `smartcontract/contracts/volatility_shield/src/test.rs`:
- `test_queue_withdraw_multiple_entries_do_not_overwrite` — two queued withdrawals from the same account get distinct ids and both remain independently retrievable (the regression this PR guards against).
- `test_queue_withdraw_multiple_accounts_independent` — two different accounts queuing withdrawals don't interfere with each other.
- `test_process_queued_withdrawal_transfers_assets` — processing a queued withdrawal transfers the correct asset amount to the requester and updates vault totals.
- `test_process_queued_withdrawal_not_found` — processing an unknown withdrawal id fails.
- `test_process_queued_withdrawal_already_processed_rejected` — processing the same withdrawal twice fails on the second attempt.
- `test_process_queued_withdrawal_unauthorized_rejected` — a non-admin caller is rejected.

Ran both required integrity gates locally:

```
$ cd smartcontract && cargo test --all
...
running 57 tests
test test::test_queue_withdraw_multiple_entries_do_not_overwrite ... ok
test test::test_queue_withdraw_multiple_accounts_independent ... ok
test test::test_process_queued_withdrawal_not_found ... ok
test test::test_process_queued_withdrawal_already_processed_rejected ... ok
test test::test_process_queued_withdrawal_transfers_assets ... ok
test test::test_process_queued_withdrawal_unauthorized_rejected ... ok
...
test result: ok. 57 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.96s
```

```
$ cargo build --target wasm32-unknown-unknown --release
   Compiling volatility_shield v0.1.0 (.../smartcontract/contracts/volatility_shield)
   Compiling mock_strategy v0.1.0 (.../smartcontract/contracts/mock_strategy)
    Finished `release` profile [optimized] target(s) in 18.02s
```

- [x] `cargo test --all` passes (57/57)
- [x] `cargo build --target wasm32-unknown-unknown --release` succeeds

Closes #62
